### PR TITLE
remove restrição para perfil equivocado

### DIFF
--- a/artefatos/StructureDefinition-BRDispensacaoMedicamento.json
+++ b/artefatos/StructureDefinition-BRDispensacaoMedicamento.json
@@ -242,15 +242,7 @@
         "path": "MedicationDispense.authorizingPrescription",
         "short": "Identificação do registro de prescrição eletrônica",
         "definition": "Referência às informações do registro de prescrição do medicamento.",
-        "max": "1",
-        "type": [
-          {
-            "code": "Reference",
-            "targetProfile": [
-              "http://www.saude.gov.br/fhir/r4/StructureDefinition/BRRegistroPrescricaoMedicamento"
-            ]
-          }
-        ]
+        "max": "1"
       },
       {
         "id": "MedicationDispense.authorizingPrescription.id",


### PR DESCRIPTION
Restrição que deveria para um dado recurso (MedicationRequest) é estabelecida para outro Composition. A restrição foi removida, naturalmente, esta mudança é temporária, introduz um erro no conjunto dos artefatos produzidos pela RNDS. Deverá ser monitorada. 